### PR TITLE
Improved core properties

### DIFF
--- a/lib/jasonette/core/properties.rb
+++ b/lib/jasonette/core/properties.rb
@@ -187,11 +187,9 @@ module Jasonette::Properties
   def property_sender target, name, *args, &block
     raise "unhandled definition! : use different property name then `#{name}`" if Object.new.methods.include?(name.to_sym)
     if block_given?
-      target.send name, *args, &block
+      target.set! name, _scope { block.call }
     elsif args.one? && args.first.is_a?(Hash)
-      target.send name do
-        args.first.each{ |key, value| set! key, value.to_s }
-      end
+      target.set! name, args.first
     else
       raise "unhandled definition!"
     end

--- a/lib/jasonette/template.rb
+++ b/lib/jasonette/template.rb
@@ -29,7 +29,7 @@ module Jasonette
 
     def jason name=nil, &block
       builder = Jasonette::Jason.new(context, &block)
-      _set_key_value name || "$jason", builder.attributes!
+      set! name || "$jason", builder.attributes!
       self
     end
     alias build jason
@@ -83,7 +83,7 @@ module Jasonette
     #
     #   builder = Jasonette::Jason::Template.new(@context)
     #   builder.with_attributes { instance_eval(&block) }
-    #   _set_key_value "template", builder.attributes!
+    #   set! "template", builder.attributes!
     #   self
     # end
     #
@@ -92,7 +92,7 @@ module Jasonette
     #
     #   builder = Jasonette::Jason::Body.new(@context)
     #   builder.with_attributes { instance_eval(&block) }
-    #   _set_key_value "body", builder.attributes!
+    #   set! "body", builder.attributes!
     #   self
     # end
   end

--- a/spec/lib/jasonette/core/base_spec.rb
+++ b/spec/lib/jasonette/core/base_spec.rb
@@ -66,19 +66,5 @@ RSpec.describe Jasonette::Base do
   it "generates expected json" do
     pending "get inline! working in test environment -- works in Rails app!"
     expect(builder.inline!("score")).to match_response_schema("zero_scores")
-  end
-
-  it "set key/values that are not easily expressed as method" do
-    build = builder.encode do
-      set! "color:disabled", "1100"
-    end
-    expect(build).to eqj "color:disabled"=>"1100"
-  end
-
-  it "#merge!" do
-    build = builder.encode do
-      merge! "title" => "foo", "color" => "1100"
-    end
-    expect(build).to eqj "title"=>"foo", "color"=>"1100"
-  end
+  end  
 end

--- a/spec/lib/jasonette/core/properties_spec.rb
+++ b/spec/lib/jasonette/core/properties_spec.rb
@@ -87,4 +87,98 @@ RSpec.describe Jasonette::Properties do
     its(:property_names) { is_expected.to include :bar, :foo }
   end
 
+  describe "Method" do
+    let(:builder) { build_with(Jasonette::Base) }
+    describe "#set!" do
+      it "build key/values that are not easily expressed as method" do
+        build = builder.encode do
+          set! "color:disabled", "1100"
+        end
+        expect(build).to eqj "color:disabled"=>"1100"
+      end
+
+      it "build any simple value as string" do
+        build = builder.encode do
+          set! "color", 1
+        end
+        expect(build).to eqj "color"=>"1"
+      end
+
+      context "with Jasonette instance" do
+        it "build instance attributrs!" do
+          _builder = build_with(Jasonette::Jason).encode do
+            color "1100"
+          end
+          build = builder.encode do
+            set! "head", _builder
+          end
+          expect(build).to eqj "head" => {"color"=>"1100"}
+        end
+      end
+
+      context "with Block" do
+        it "build its content" do
+          build = builder.encode do
+            set! "color" do
+              white "000000"
+              black "fffff"
+            end  
+          end
+          expect(build).to eqj "color" => {"white"=>"000000", "black"=>"fffff"}
+        end
+
+        context "having argument as collection" do  
+          it "build its content with Array values" do
+            build = builder.encode do
+              set! "color", [{ encode: "000000", name: "white" }, { encode: "fffff", name: "black" }] do |color|
+                set! color[:name], color[:encode]
+              end  
+            end
+            expect(build).to eqj "color" => [{"white"=>"000000"}, {"black"=>"fffff"}]
+          end
+
+          it "build its content with Hash values" do
+            build = builder.encode do
+              set! "color", { "white"=>"000000", "black"=>"fffff" } do |color_name, encode|
+                set! color_name, encode
+              end  
+            end
+            expect(build).to eqj "color" => [{"white"=>"000000"}, {"black"=>"fffff"}]
+          end
+        end
+      end
+
+      context "without Block" do
+        it "build collection" do
+          build = builder.encode do
+            set! "color", [{ encode: "000000", name: "white" }, { encode: "fffff", name: "black" }], :encode, :name
+          end
+          expect(build).to eqj "color" => [{"encode"=>"000000", "name"=>"white"}, {"encode"=>"fffff", "name"=>"black"}]
+        end
+      end  
+    end 
+
+    describe "#merge!" do
+      context "with hash having symbolised key, integer value" do
+        it "build hash key/value in string" do
+          build = builder.encode do
+            merge! title: "foo", "color" => "1100", file: 1 
+          end
+          expect(build).to eqj "title"=>"foo", "color"=>"1100", "file"=>"1"
+        end
+      end
+
+      context "with Jasonette instance" do
+        it "build attributrs" do
+          _builder = build_with(Jasonette::Jason).encode do
+            color "1100"
+          end
+          build = builder.encode do
+            merge! _builder
+          end
+          expect(build).to eqj "color"=>"1100"
+        end
+      end
+    end
+  end
 end

--- a/spec/test_app/app/views/posts/helper.jasonette
+++ b/spec/test_app/app/views/posts/helper.jasonette
@@ -7,4 +7,8 @@ head do
       "_with_block"
     end)
   end
+
+  style :post_foo do
+    color "white"
+  end
 end

--- a/spec/test_app/spec/controllers/posts_controller_spec.rb
+++ b/spec/test_app/spec/controllers/posts_controller_spec.rb
@@ -23,10 +23,10 @@ describe PostsController do
       expect(JSON.parse(response.body)).to eq({"$jason"=>{"body"=>{"sections"=>[{"type"=>"partial", "items"=>[{"text"=>"Foo", "type"=>"label"}, {"text"=>"Bar", "type"=>"label"}]}]}, "foo"=>"bar"}})
     end
 
-    it "can call helper methods" do
+    it "can call helper methods and build style block without calling helper" do
       request.accept = "application/json"
       get :helper, format: :json
-      expect(JSON.parse(response.body)).to eq({"$jason"=>{"head"=>{"data"=>{"foo"=>"foo", "app_foo"=>"app_foo", "post_foo"=>"post_foo", "block_foo"=>"app_foo_with_block"}}}})
+      expect(JSON.parse(response.body)).to eq({"$jason"=>{"head"=>{"styles"=>{"post_foo"=>{"color"=>"white"}},"data"=>{"foo"=>"foo", "app_foo"=>"app_foo", "post_foo"=>"post_foo", "block_foo"=>"app_foo_with_block"}}}})
     end
 
     let(:action_partial_json) do


### PR DESCRIPTION
Improved property set!, merge! :
- Added Jasonette instance merge support

Changed property_sender to resolve below issue :
- Issue :  It send argument `name` in context of target. If any helper or property is defined with same name then its execute helper/property rather then simply set `name` as key.