### PR TITLE
Jasonette helpers and improvement

### DIFF
--- a/lib/jasonette/core/action.rb
+++ b/lib/jasonette/core/action.rb
@@ -7,7 +7,7 @@ module Jasonette
     def trigger name, &block
       with_attributes do
         set! "trigger", name
-        instance_eval(&block) if block_given?
+        encode(&block) if block_given?
       end
     end
 
@@ -21,21 +21,13 @@ module Jasonette
 
     def success &block
       @success = Jasonette::Action.new(context) do
-        with_attributes do
-          if block_given?
-            instance_eval(&block)
-          else
-            render!
-          end
-        end
+        block_given? ? encode(&block) : render!
       end
       self
     end
 
     def error &block
-      @error = Jasonette::Action.new(context) do
-        with_attributes { instance_eval(&block) }
-      end
+      @error = Jasonette::Action.new(context, &block)
       self
     end
   end

--- a/lib/jasonette/core/base.rb
+++ b/lib/jasonette/core/base.rb
@@ -143,10 +143,8 @@ module Jasonette
         []
       elsif ::Kernel.block_given?
         _map_collection(collection, &::Proc.new)
-      elsif attributes.any?
-        _map_collection(collection) { |element| extract! element, *attributes }
       else
-        collection.to_a
+        _map_collection(collection) { |element| extract! element, *attributes }
       end
 
       merge! array
@@ -155,6 +153,8 @@ module Jasonette
     def extract!(object, *attributes)
       if ::Hash === object
         _extract_hash_values(object, attributes)
+      elsif Jasonette::Base === object
+        _extract_hash_values(object.attributes!, attributes)
       else
         _extract_method_values(object, attributes)
       end
@@ -186,7 +186,7 @@ module Jasonette
     private
 
     def context_method name, *args, &block
-      context.send(name, *args, &block)
+      context.public_send(name, *args, &block)
     end
 
     def _extract_hash_values(object, attributes)

--- a/lib/jasonette/core/base.rb
+++ b/lib/jasonette/core/base.rb
@@ -14,7 +14,7 @@ module Jasonette
         begin
           return context_method(name, *args, &block)
         rescue
-          set!(name) { instance_eval(&block) }
+          set!(name) { encode(&block) }
         end
       end
     end
@@ -51,7 +51,7 @@ module Jasonette
       @attributes = {}
 
       self.extend ContexEmbedder if @context.present?
-      instance_eval(&::Proc.new) if ::Kernel.block_given?
+      encode(&::Proc.new) if ::Kernel.block_given?
     end
 
     # Fixed for below error : 

--- a/lib/jasonette/core/base.rb
+++ b/lib/jasonette/core/base.rb
@@ -54,6 +54,14 @@ module Jasonette
       instance_eval(&::Proc.new) if ::Kernel.block_given?
     end
 
+    # Fixed for below error : 
+    # IOError - not opened for reading:
+    # activesupport (5.0.1) lib/active_support/core_ext/object/json.rb:130:in `as_json'
+    # Eventually called by multi_json/adapter.rb:25:in `dump'
+    def as_json(options = nil)
+      attributes!
+    end
+
     def target!
       ::MultiJson.dump attributes!
     end

--- a/lib/jasonette/core/body/header.rb
+++ b/lib/jasonette/core/body/header.rb
@@ -6,7 +6,7 @@ module Jasonette
       item = Jasonette::Item.new(context) do
         text caption unless caption.nil?
         image image_uri unless image_uri.nil?
-        with_attributes { instance_eval(&::Proc.new) } if block_given?
+        encode(&::Proc.new) if block_given?
       end
       append item, "menu"
     end

--- a/lib/jasonette/core/item.rb
+++ b/lib/jasonette/core/item.rb
@@ -6,7 +6,7 @@ module Jasonette
     def badge caption=nil
       item = self.class.new(context) do
         text caption unless caption.nil?
-        instance_eval(&::Proc.new) if block_given?
+        encode(&::Proc.new) if block_given?
       end
       append item, "badge"
     end

--- a/lib/jasonette/core/items.rb
+++ b/lib/jasonette/core/items.rb
@@ -5,7 +5,7 @@ module Jasonette
       item = Jasonette::Item.new(context) do
         text caption unless caption.nil?
         type "label" unless skip_type
-        with_attributes { instance_eval(&::Proc.new) } if block_given?
+        encode(&::Proc.new) if block_given?
       end
       append item
     end
@@ -14,7 +14,7 @@ module Jasonette
       item = Jasonette::Item.new(context) do
         text caption unless caption.nil?
         type "text" unless skip_type
-        with_attributes { instance_eval(&::Proc.new) } if block_given?
+        encode(&::Proc.new) if block_given?
       end
       append item
     end
@@ -23,7 +23,7 @@ module Jasonette
       item = Jasonette::Item.new(context) do
         type "video" unless skip_type
         file_url uri unless uri.nil?
-        with_attributes { instance_eval(&::Proc.new) } if block_given?
+        encode(&::Proc.new) if block_given?
       end
       append item
     end
@@ -31,10 +31,8 @@ module Jasonette
     def image uri=nil, skip_type=false, url_key="url"
       item = Jasonette::Item.new(context) do
         type "image" unless skip_type
-        with_attributes do
-          set! url_key, uri unless uri.nil?
-          instance_eval(&::Proc.new) if block_given?
-        end
+        set! url_key, uri unless uri.nil?
+        encode(&::Proc.new) if block_given?
       end
       append item
     end
@@ -45,10 +43,7 @@ module Jasonette
         unless caption.nil?
           is_url ? (url caption) : (text caption)
         end
-
-        with_attributes do
-          instance_eval(&::Proc.new) if block_given?
-        end
+        encode(&::Proc.new) if block_given?
       end
       append item
     end
@@ -58,10 +53,7 @@ module Jasonette
         type "slider" unless skip_type
         name name
         value value unless value.nil?
-
-        with_attributes do
-          instance_eval(&::Proc.new) if block_given?
-        end
+        encode(&::Proc.new) if block_given?
       end
       append item
     end
@@ -69,7 +61,7 @@ module Jasonette
     def layout orientation="vertical"
       item = Jasonette::Layout.new(context) do
         type orientation
-        with_attributes { instance_eval(&::Proc.new) } if block_given?
+        encode(&::Proc.new) if block_given?
       end
       append item
     end
@@ -79,7 +71,7 @@ module Jasonette
         type "textfield" unless skip_type
         name name unless name.nil?
         value value unless value.nil?
-        with_attributes { instance_eval(&::Proc.new) } if block_given?
+        encode(&::Proc.new) if block_given?
       end
       append item
     end
@@ -89,7 +81,7 @@ module Jasonette
         type "textarea" unless skip_type
         name name unless name.nil?
         value value unless value.nil?
-        with_attributes { instance_eval(&::Proc.new) } if block_given?
+        encode(&::Proc.new) if block_given?
       end
       append item
     end
@@ -98,17 +90,15 @@ module Jasonette
       item = Jasonette::Item.new(context) do
         type "space" unless skip_type
         height height unless height.nil?
-        with_attributes { instance_eval(&::Proc.new) } if block_given?
+        encode(&::Proc.new) if block_given?
       end
       append item
     end
 
     def merge! items
       item = Jasonette::Item.new(context) do
-        with_attributes do
-          items.each { |k, v| set! k, v }
-          instance_eval(&::Proc.new) if block_given?
-        end
+        items.each { |k, v| set! k, v }
+        encode(&::Proc.new) if block_given?
       end
       append item
     end

--- a/lib/jasonette/helpers.rb
+++ b/lib/jasonette/helpers.rb
@@ -1,0 +1,14 @@
+module Jasonette
+  module Helpers
+    def jason_builder property_name=nil, context=nil, &block
+      klass = Jasonette::Jason.new("").klass_for_property property_name
+      builder(klass, context, &block)
+    end
+
+    private
+
+    def builder klass, context, &block
+      klass.new(context || self, &block)
+    end
+  end
+end

--- a/lib/jasonette/jason/head.rb
+++ b/lib/jasonette/jason/head.rb
@@ -9,7 +9,7 @@ module Jasonette
     def template name, *args, &block
       if block_given?
         item = Jasonette::Body.new(context) do
-          with_attributes { instance_eval(&block) }
+          encode(&block)
         end
         append item, "templates", name
       else
@@ -29,7 +29,7 @@ module Jasonette
     def action name, *args, &block
       if block_given?
         item = Jasonette::Action.new(context) do
-          with_attributes { instance_eval(&block) }
+          encode(&block)
         end
         append item, "actions", name
       else

--- a/lib/jasonette/railtie.rb
+++ b/lib/jasonette/railtie.rb
@@ -1,12 +1,14 @@
 require 'rails/railtie'
 require 'jasonette/handler'
 require 'jasonette/action_view_extensions'
+require 'jasonette/helpers'
 
 module Jasonette
   class Railtie < ::Rails::Railtie
     initializer :jasonette do
       ActiveSupport.on_load :action_view do
         ActionView::Template.register_template_handler :jasonette, Jasonette::Handler
+        include Jasonette::Helpers
       end
 
       # if Rails::VERSION::MAJOR >= 5

--- a/spec/lib/jasonette/core/base_spec.rb
+++ b/spec/lib/jasonette/core/base_spec.rb
@@ -164,9 +164,7 @@ RSpec.describe Jasonette::Base do
 
     context "with Jasonette instance" do
       it "build attributes" do
-        _builder = build_with(Jasonette::Jason).encode do
-          color "1100"
-        end
+        _builder = build_with(Jasonette::Jason) { color "1100" }
         build = builder.encode do
           merge! _builder
         end
@@ -176,31 +174,23 @@ RSpec.describe Jasonette::Base do
   end
 
   describe "#as_json use" do
-    context "without defination of as_json" do
+    context "without defination of as_json", shared_context: :remove_as_json do
       it "build wrong target!" do
-        pending "Find a way to undefine and redefine :as_json method"
-        _builder = build_with(Jasonette::Jason).encode do
-          color "1100"
-        end
-        _builder.instance_eval('undef :as_json')
-
+        _builder = build_with(Jasonette::Jason) { color "1100" }
         build = builder.encode do
           set! "style", [_builder]
         end
-        expect(build.target!).to eq "color"=>"1100"
+        expect(JSON.parse(build.target!)["style"].first).to_not include "color"
       end
     end
 
     context "with defination of as_json" do
       it "build target!" do
-        _builder = build_with(Jasonette::Jason).encode do
-          color "1100"
-        end
-
+        _builder = build_with(Jasonette::Jason) { color "1100" }
         build = builder.encode do
           set! "style", [_builder]
         end
-        expect(build.target!).to eq "{\"style\":[{\"color\":\"1100\"}]}"
+        expect(JSON.parse(build.target!)).to eq "style" => [{"color"=>"1100"}]
       end
     end
   end

--- a/spec/lib/jasonette/core/base_spec.rb
+++ b/spec/lib/jasonette/core/base_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Jasonette::Base do
 
-  let(:builder) { build_with(Jasonette::Base) }
+  let(:builder) { build_with(described_class) }
 
   context "#image_url" do
     it "can use actionview asset helpers" do
@@ -67,4 +67,111 @@ RSpec.describe Jasonette::Base do
     pending "get inline! working in test environment -- works in Rails app!"
     expect(builder.inline!("score")).to match_response_schema("zero_scores")
   end  
+
+  describe "#set!" do
+    it "builds key/values that are not easily expressed as method" do
+      build = builder.encode do
+        set! "color:disabled", "1100"
+      end
+      expect(build).to eqj "color:disabled"=>"1100"
+    end
+
+    it "builds any simple value as string" do
+      build = builder.encode do
+        set! "color", 1
+      end
+      expect(build).to eqj "color"=>"1"
+    end
+
+    context "with Jasonette instance" do
+      it "builds instance attributes!" do
+        _builder = build_with(Jasonette::Jason).encode do
+          color "1100"
+        end
+        build = builder.encode do
+          set! "head", _builder
+        end
+        expect(build).to eqj "head" => {"color"=>"1100"}
+      end
+    end
+
+    context "with Block" do
+      it "builds content" do
+        build = builder.encode do
+          set! "color" do
+            white "000000"
+            black "fffff"
+          end  
+        end
+        expect(build).to eqj "color" => {"white"=>"000000", "black"=>"fffff"}
+      end
+
+      context "having argument as collection" do  
+        it "builds content with Array values" do
+          build = builder.encode do
+            set! "color", [{ encode: "000000", name: "white" }, { encode: "fffff", name: "black" }] do |color|
+              set! color[:name], color[:encode]
+            end  
+          end
+          expect(build).to eqj "color" => [{"white"=>"000000"}, {"black"=>"fffff"}]
+        end
+
+        it "builds content with Hash values" do
+          build = builder.encode do
+            set! "color", { "white"=>"000000", "black"=>"fffff" } do |color_name, encode|
+              set! color_name, encode
+            end  
+          end
+          expect(build).to eqj "color" => [{"white"=>"000000"}, {"black"=>"fffff"}]
+        end
+      end
+    end
+
+    context "without Block" do
+      it "builds collection" do
+        build = builder.encode do
+          set! "color", [{ encode: "000000", name: "white" }, { encode: "fffff", name: "black" }], :encode, :name
+        end
+        expect(build).to eqj "color" => [{"encode"=>"000000", "name"=>"white"}, {"encode"=>"fffff", "name"=>"black"}]
+      end
+    end  
+  end
+
+  describe "#array!" do
+    context "with Jasonette instance collections" do
+      let(:builder1) { build_with(described_class) { set! "builder", "1" } }
+      let(:builder2) { build_with(described_class) { set! "builder", "2" } }
+
+      it "builds builder value" do
+        collection = [builder1, builder2, {"no_builder"=>"3"}, 4]
+        build = builder.encode do
+          array! collection
+        end
+        expect(build).to eqj [{"builder"=>"1"}, {"builder"=>"2"}, {"no_builder"=>"3"}, 4]
+      end
+    end
+  end  
+
+  describe "#merge!" do
+    context "with hash having symbolised key, integer value" do
+      it "build hash key/value in string" do
+        build = builder.encode do
+          merge! title: "foo", "color" => "1100", file: 1 
+        end
+        expect(build).to eqj "title"=>"foo", "color"=>"1100", "file"=>"1"
+      end
+    end
+
+    context "with Jasonette instance" do
+      it "build attributes" do
+        _builder = build_with(Jasonette::Jason).encode do
+          color "1100"
+        end
+        build = builder.encode do
+          merge! _builder
+        end
+        expect(build).to eqj "color"=>"1100"
+      end
+    end
+  end
 end

--- a/spec/lib/jasonette/core/base_spec.rb
+++ b/spec/lib/jasonette/core/base_spec.rb
@@ -174,4 +174,34 @@ RSpec.describe Jasonette::Base do
       end
     end
   end
+
+  describe "#as_json use" do
+    context "without defination of as_json" do
+      it "build wrong target!" do
+        pending "Find a way to undefine and redefine :as_json method"
+        _builder = build_with(Jasonette::Jason).encode do
+          color "1100"
+        end
+        _builder.instance_eval('undef :as_json')
+
+        build = builder.encode do
+          set! "style", [_builder]
+        end
+        expect(build.target!).to eq "color"=>"1100"
+      end
+    end
+
+    context "with defination of as_json" do
+      it "build target!" do
+        _builder = build_with(Jasonette::Jason).encode do
+          color "1100"
+        end
+
+        build = builder.encode do
+          set! "style", [_builder]
+        end
+        expect(build.target!).to eq "{\"style\":[{\"color\":\"1100\"}]}"
+      end
+    end
+  end
 end

--- a/spec/lib/jasonette/core/properties_spec.rb
+++ b/spec/lib/jasonette/core/properties_spec.rb
@@ -89,94 +89,21 @@ RSpec.describe Jasonette::Properties do
 
   describe "Method" do
     let(:builder) { build_with(Jasonette::Base) }
-    describe "#set!" do
-      it "build key/values that are not easily expressed as method" do
-        build = builder.encode do
-          set! "color:disabled", "1100"
-        end
-        expect(build).to eqj "color:disabled"=>"1100"
-      end
-
-      it "build any simple value as string" do
-        build = builder.encode do
-          set! "color", 1
-        end
-        expect(build).to eqj "color"=>"1"
-      end
-
-      context "with Jasonette instance" do
-        it "build instance attributrs!" do
-          _builder = build_with(Jasonette::Jason).encode do
-            color "1100"
-          end
-          build = builder.encode do
-            set! "head", _builder
-          end
-          expect(build).to eqj "head" => {"color"=>"1100"}
+    
+    describe "#property_sender" do
+      context "with block" do
+        it "build target with block values" do
+          target = build_with(Jasonette::Jason::Head) 
+          builder.property_sender target, "color", &Proc.new { builder.instance_eval { padding "1" } }
+          expect(target).to eqj "color" => {"padding"=>"1"}
         end
       end
 
-      context "with Block" do
-        it "build its content" do
-          build = builder.encode do
-            set! "color" do
-              white "000000"
-              black "fffff"
-            end  
-          end
-          expect(build).to eqj "color" => {"white"=>"000000", "black"=>"fffff"}
-        end
-
-        context "having argument as collection" do  
-          it "build its content with Array values" do
-            build = builder.encode do
-              set! "color", [{ encode: "000000", name: "white" }, { encode: "fffff", name: "black" }] do |color|
-                set! color[:name], color[:encode]
-              end  
-            end
-            expect(build).to eqj "color" => [{"white"=>"000000"}, {"black"=>"fffff"}]
-          end
-
-          it "build its content with Hash values" do
-            build = builder.encode do
-              set! "color", { "white"=>"000000", "black"=>"fffff" } do |color_name, encode|
-                set! color_name, encode
-              end  
-            end
-            expect(build).to eqj "color" => [{"white"=>"000000"}, {"black"=>"fffff"}]
-          end
-        end
-      end
-
-      context "without Block" do
-        it "build collection" do
-          build = builder.encode do
-            set! "color", [{ encode: "000000", name: "white" }, { encode: "fffff", name: "black" }], :encode, :name
-          end
-          expect(build).to eqj "color" => [{"encode"=>"000000", "name"=>"white"}, {"encode"=>"fffff", "name"=>"black"}]
-        end
-      end  
-    end 
-
-    describe "#merge!" do
-      context "with hash having symbolised key, integer value" do
-        it "build hash key/value in string" do
-          build = builder.encode do
-            merge! title: "foo", "color" => "1100", file: 1 
-          end
-          expect(build).to eqj "title"=>"foo", "color"=>"1100", "file"=>"1"
-        end
-      end
-
-      context "with Jasonette instance" do
-        it "build attributrs" do
-          _builder = build_with(Jasonette::Jason).encode do
-            color "1100"
-          end
-          build = builder.encode do
-            merge! _builder
-          end
-          expect(build).to eqj "color"=>"1100"
+      context "with arguments" do
+        it "build target with argument" do
+          target = build_with(Jasonette::Jason::Head) 
+          builder.property_sender target, "color", {"padding"=>"2"}
+          expect(target).to eqj "color" => {"padding"=>"2"}
         end
       end
     end

--- a/spec/lib/jasonette/core/properties_spec.rb
+++ b/spec/lib/jasonette/core/properties_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe Jasonette::Properties do
       context "with block" do
         it "build target with block values" do
           target = build_with(Jasonette::Jason::Head) 
-          builder.property_sender target, "color", &Proc.new { builder.instance_eval { padding "1" } }
+          builder.property_sender target, "color", &Proc.new { builder.encode { padding "1" } }
           expect(target).to eqj "color" => {"padding"=>"1"}
         end
       end

--- a/spec/lib/jasonette/jason_spec.rb
+++ b/spec/lib/jasonette/jason_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Jasonette::Jason do
 
-  let(:builder) { build_with(Jasonette::Jason) }
+  let(:builder) { build_with(described_class) }
 
   require 'pry'
 

--- a/spec/support/shared_context.rb
+++ b/spec/support/shared_context.rb
@@ -1,0 +1,4 @@
+shared_context "without defination of as_json", :shared_context => :remove_as_json do
+  before { class Jasonette::Base; remove_method(:as_json); end }
+  after { load "#{"Jasonette::Core::Base".underscore}.rb" }
+end

--- a/spec/test_app/app/helpers/posts_helper.rb
+++ b/spec/test_app/app/helpers/posts_helper.rb
@@ -2,4 +2,22 @@ module PostsHelper
   def post_foo
     "post_foo"
   end
+
+  def add_jason_builder_posts
+    jason_builder(:head) do
+      action "test" do
+        success
+      end 
+    end
+  end 
+
+  def public_posts val
+    { "public_helper_posts" => val }
+  end
+
+  private
+
+  def private_posts val
+    { "private_helper_posts" => val }
+  end
 end

--- a/spec/test_app/app/views/posts/as_json.jasonette
+++ b/spec/test_app/app/views/posts/as_json.jasonette
@@ -1,0 +1,3 @@
+head do
+  set! "as_json", [add_jason_builder_posts]
+end

--- a/spec/test_app/app/views/posts/helper.jasonette
+++ b/spec/test_app/app/views/posts/helper.jasonette
@@ -11,4 +11,9 @@ head do
   style :post_foo do
     color "white"
   end
+
+  merge! private_posts(["post"])
+  merge! public_posts(["post"])
+
+  merge! add_jason_builder_posts
 end

--- a/spec/test_app/config/routes.rb
+++ b/spec/test_app/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
       get "with_layout"
       get "without_layout"
       get "with_template_vars"
+      get "as_json"
     end
   end
 

--- a/spec/test_app/spec/controllers/posts_controller_spec.rb
+++ b/spec/test_app/spec/controllers/posts_controller_spec.rb
@@ -108,4 +108,26 @@ describe PostsController do
       end  
     end  
   end
+
+  describe "#as_json use" do
+    context "without defination of as_json" do
+      it "build wrong target!" do
+        pending "Find a way to undefine and redefine :as_json method"
+        # class Jasonette::Base; remove_method(:as_json); end
+        # class Jasonette::Base; redefine_method(:as_json); end
+
+        request.accept = "application/json"
+        get :as_json, format: :json
+        expect(JSON.parse(response.body)["$jason"]).to include "private_posts"=>["post"], "public_helper_posts"=>["post"]
+      end
+    end
+
+    context "with defination of as_json" do
+      it "build target!" do
+        request.accept = "application/json"
+        get :as_json, format: :json
+        expect(JSON.parse(response.body)["$jason"]).to include "head" => {"as_json"=>[{"actions"=>{"test"=>{"success"=>{"type"=>"$render"}}}}]}
+      end
+    end
+  end
 end

--- a/spec/test_app/spec/controllers/posts_controller_spec.rb
+++ b/spec/test_app/spec/controllers/posts_controller_spec.rb
@@ -23,12 +23,6 @@ describe PostsController do
       expect(JSON.parse(response.body)).to eq({"$jason"=>{"body"=>{"sections"=>[{"type"=>"partial", "items"=>[{"text"=>"Foo", "type"=>"label"}, {"text"=>"Bar", "type"=>"label"}]}]}, "foo"=>"bar"}})
     end
 
-    it "can call helper methods and build style block without calling helper" do
-      request.accept = "application/json"
-      get :helper, format: :json
-      expect(JSON.parse(response.body)).to eq({"$jason"=>{"head"=>{"styles"=>{"post_foo"=>{"color"=>"white"}},"data"=>{"foo"=>"foo", "app_foo"=>"app_foo", "post_foo"=>"post_foo", "block_foo"=>"app_foo_with_block"}}}})
-    end
-
     let(:action_partial_json) do
       { "$jason" => {
           "head" => {
@@ -63,8 +57,8 @@ describe PostsController do
     end
   end
 
-  context "render" do
-    describe "without layout" do
+  describe "render" do
+    context "without layout" do
       it "builds only template" do
         request.accept = "application/json"
         get :without_layout, format: :json
@@ -72,7 +66,7 @@ describe PostsController do
       end
     end
 
-    describe "with layout" do
+    context "with layout" do
       it "builds layout and template" do
         request.accept = "application/json"
         get :with_layout, format: :json
@@ -85,5 +79,33 @@ describe PostsController do
         expect(JSON.parse(response.body)).to eq("$jason"=>{"head"=>{"foo"=>"in template", "template_var_foo"=>"foo", "template_var_bar"=>"bar", "template_var_baz"=>"baz"}})
       end
     end
+  end
+
+  describe "calling helpers" do
+    it "builds helper" do
+      request.accept = "application/json"
+      get :helper, format: :json
+      expect(JSON.parse(response.body)["$jason"]["head"]).to include "data"=>{"foo"=>"foo", "app_foo"=>"app_foo", "post_foo"=>"post_foo", "block_foo"=>"app_foo_with_block"}
+    end
+
+    it "builds without calling helper" do
+      request.accept = "application/json"
+      get :helper, format: :json
+      expect(JSON.parse(response.body)["$jason"]["head"]).to include "styles"=>{"post_foo"=>{"color"=>"white"}}
+    end
+
+    it "builds only public helper" do
+      request.accept = "application/json"
+      get :helper, format: :json
+      expect(JSON.parse(response.body)["$jason"]["head"]).to include "private_posts"=>["post"], "public_helper_posts"=>["post"]
+    end
+
+    context "have jason_builder" do
+      it "builds builder attributes" do
+        request.accept = "application/json"
+        get :helper, format: :json
+        expect(JSON.parse(response.body)["$jason"]["head"]).to include "actions" => {"test"=>{"success"=>{"type"=>"$render"}}}
+      end  
+    end  
   end
 end

--- a/spec/test_app/spec/controllers/posts_controller_spec.rb
+++ b/spec/test_app/spec/controllers/posts_controller_spec.rb
@@ -110,15 +110,9 @@ describe PostsController do
   end
 
   describe "#as_json use" do
-    context "without defination of as_json" do
+    context "without defination of as_json", shared_context: :remove_as_json do
       it "build wrong target!" do
-        pending "Find a way to undefine and redefine :as_json method"
-        # class Jasonette::Base; remove_method(:as_json); end
-        # class Jasonette::Base; redefine_method(:as_json); end
-
-        request.accept = "application/json"
-        get :as_json, format: :json
-        expect(JSON.parse(response.body)["$jason"]).to include "private_posts"=>["post"], "public_helper_posts"=>["post"]
+        expect { get :as_json, format: :json }.to raise_error ActionView::Template::Error, "not opened for reading"
       end
     end
 


### PR DESCRIPTION
- Updated to call only public helpers
- Added helpers to use in railtie environment : `:jason_builder`
- Updated `:array!` method for builder instance collection
- Fixed "not opened for reading" error
- Added coverage to use of `:as_json` method
- Improved by changing "instance_eval" with "encode" in core dir