### PR TITLE
Fixes to resolve issue in multi-threaded requests and changes to make core independent

### DIFF
--- a/lib/jasonette.rb
+++ b/lib/jasonette.rb
@@ -25,8 +25,6 @@ require_relative 'jasonette/jason/head/actions'
 require_relative 'jasonette/jason/head/templates'
 require_relative 'jasonette/jason/body'
 
-require_relative 'jasonette/template'
-
 module Jasonette
   def self.setup
     yield self

--- a/lib/jasonette/action_view_extensions.rb
+++ b/lib/jasonette/action_view_extensions.rb
@@ -5,8 +5,8 @@ module Jasonette
       path, locals  = options[:layout], options[:locals] || {}
       layout        = path && find_layout(path, locals.keys, [formats.first])
       if !layout.try(:virtual_path).nil?
-        JasonSingleton.fetch(context).layout = layout
-        JasonSingleton.fetch(context).locals = locals
+        JasonSingleton.fetch(context).__layout = layout
+        JasonSingleton.fetch(context).__locals = locals
       end
       super
     end

--- a/lib/jasonette/handler.rb
+++ b/lib/jasonette/handler.rb
@@ -1,3 +1,5 @@
+require 'jasonette/template'
+
 module Jasonette
   class Handler
     cattr_accessor :default_format
@@ -5,7 +7,7 @@ module Jasonette
 
     def self.call(template)
       has_jasonette_handler = template.locals.include?("_jasonette_handler")
-      %{__already_defined = defined?(jason); if(#{has_jasonette_handler}); _jasonette_handler.encode(&Proc.new {#{template.source}}); else; jason||=Jasonette::Template.load(self); if jason.has_layout?(#{template.object_id}); jason = jason.new_jason(#{template.object_id}); else; jason.jason(&Proc.new {#{template.source}}); end; end;
+      %{__already_defined = defined?(jason); jason ||= Jasonette::Template.load(self); if(jason && #{has_jasonette_handler}); jason.encode(_jasonette_handler, &Proc.new {#{template.source}}); else; if jason.has_layout?(#{template.object_id}); jason = jason.new_jason(#{template.object_id}); else; jason.jason(&Proc.new {#{template.source}}); end; end;
         jason.target! unless ((__already_defined && __already_defined != "method") || #{has_jasonette_handler})}
     end
   end

--- a/lib/jasonette/helpers.rb
+++ b/lib/jasonette/helpers.rb
@@ -2,7 +2,31 @@ module Jasonette
   module Helpers
     def jason_builder property_name=nil, context=nil, &block
       klass = Jasonette::Jason.new("").klass_for_property property_name
-      builder(klass, context, &block)
+
+      builder = builder(klass, context, &block)
+      if ::Kernel.block_given?
+        builder
+      else
+        BlockBuilder.new builder
+      end
+    end
+
+    class BlockBuilder
+      attr_reader :builder
+      def initialize builder
+        @builder = builder
+      end
+
+      def method_missing name, *args, &block
+        next_builder = builder.public_send name, *args
+        j.encode(next_builder, &block) if ::Kernel.block_given?
+        next_builder
+      end
+
+      private
+      def j
+        JasonSingleton.fetch(builder.context)
+      end
     end
 
     private

--- a/lib/jasonette/jason/head.rb
+++ b/lib/jasonette/jason/head.rb
@@ -8,9 +8,7 @@ module Jasonette
 
     def template name, *args, &block
       if block_given?
-        item = Jasonette::Body.new(context) do
-          encode(&block)
-        end
+        item = Jasonette::Body.new(context, &block)
         append item, "templates", name
       else
         property_sender templates, name, *args
@@ -28,9 +26,7 @@ module Jasonette
 
     def action name, *args, &block
       if block_given?
-        item = Jasonette::Action.new(context) do
-          encode(&block)
-        end
+        item = Jasonette::Action.new(context, &block)
         append item, "actions", name
       else
         property_sender actions, name, *args

--- a/lib/jasonette/template.rb
+++ b/lib/jasonette/template.rb
@@ -29,38 +29,173 @@ module Jasonette
     end
   end
 
-  class Template < Jasonette::Base
-    attr_accessor :layout, :locals
+  class Template
+    class << self
+      attr_accessor :template_lookup_options
 
-    def self.load context
-      JasonSingleton.fetch context
+      def load context
+        JasonSingleton.fetch context
+      end
+    end
+    self.template_lookup_options = { handlers: [:jasonette] }
+
+    def method_missing name, *args, &block
+      if _last_builder
+        if _last_builder.property_names.include? name
+          _last_builder.public_send name, *args, &block
+        else
+          begin
+            context_method name, *args, &block
+          rescue
+            _last_builder.public_send name, *args, &block
+          end
+        end
+      else
+        context_method name, *args, &block
+      end
+    end
+
+    attr_accessor :__layout, :__locals
+    attr_reader   :context, :attributes
+
+    def initialize context
+      @context = context
+      @attributes = {}
+      @blocks = []
+      self.extend ContexEmbedder if @context.present?
+    end
+
+    def has_layout? template_id
+      template = _get_view_template(template_id)
+      _layout_path && _layout_path != template.virtual_path
+    end
+
+    def new_jason template_id
+      new_jason = self.class.new context
+      new_jason.attributes["_template"] = "#{template_id}"
+      new_jason
+    end
+
+    def encode builder, &block
+      if ::Kernel.block_given?
+        @blocks << block
+        block.instance_variable_set("@builder", builder)
+        instance_eval(&block)
+        @blocks.delete(block)
+      else
+        raise "Wrong encode"
+      end
+      self
     end
 
     def jason name=nil, &block
-      builder = Jasonette::Jason.new(context, &block)
-      set! name || "$jason", builder.attributes!
+      builder = Jasonette::Jason.new(context)
+      encode(builder, &block)
+      @attributes[name || "$jason"] = builder.attributes!
       JasonSingleton.reset context
       self
     end
     alias build jason
 
-    def has_layout? template_id
-      template = get_view_template(template_id)
-      layout_path && layout_path != template.virtual_path
+    def attributes!
+      @attributes
     end
 
-    def layout_path
-      layout && layout.try(:virtual_path)
+    def target!
+      ::MultiJson.dump attributes!
     end
 
-    def get_view_template template_id
+    def set! name, object = nil, *args
+      super
+    end
+
+    def array! collection = [], *args
+      super
+    end
+
+    def extract! object, *attributes
+      super
+    end
+
+    def merge! key
+      case key
+      when ActiveSupport::SafeBuffer
+        values = ::MultiJson.load(key) || {}
+
+        if template = _get_view_template(values["_template"])
+          options = { locals: __locals, template: template.virtual_path }
+          _render_partial_with_options options
+        end
+      else
+        super
+      end
+      @attributes
+    end
+
+    def partial! *args
+      _render_explicit_partial(*args)
+    end
+
+    private
+
+    def context_method name, *args, &block
+      context.public_send(name, *args, &block)
+    end
+
+    def _last_builder
+      @blocks.last.instance_variable_get("@builder")
+    end
+
+    def _layout_path
+      __layout && __layout.try(:virtual_path)
+    end
+
+    def _get_view_template template_id
       ObjectSpace._id2ref(template_id.to_i)
     end
 
-    def new_jason template_id
-      new_jason = self.class.new context
-      new_jason.set! "_template", "#{template_id}"
-      new_jason
+    def _render_explicit_partial(name_or_options, locals = {})
+      case name_or_options
+        when ::Hash
+          # partial! partial: 'name', foo: 'bar'
+          options = name_or_options
+        else
+          # partial! 'name', locals: {foo: 'bar'}
+          if locals.one? && (locals.keys.first == :locals)
+            options = locals.merge(partial: name_or_options)
+          else
+            options = { partial: name_or_options, locals: locals }
+          end
+        # partial! 'name', foo: 'bar'
+        # TODO : Add feature for option :as and :collection
+        # as = locals.delete(:as)
+        # options[:as] = as if as.present?
+        # options[:collection] = locals[:collection] if locals.key?(:collection)
+      end
+
+      _render_partial_with_options options
+    end
+
+    def _render_partial_with_options(options)
+      options.reverse_merge! locals: {}
+      options.reverse_merge! self.class.template_lookup_options
+
+      _render_partial options
+    end
+
+    def _render_partial(options)
+      options[:locals].merge! _jasonette_handler: _last_builder
+      context.render options
+    end
+  end
+
+  module ContexEmbedder
+    def self.extended(klass_obj)
+      context = klass_obj.context
+      context.instance_variables.each do |var|
+        raise "Jason is using #{var} instance variable. Please change variable name." if klass_obj.instance_variable_get(var)
+        klass_obj.instance_variable_set var, context.instance_variable_get(var)
+      end
     end
   end
 end

--- a/spec/lib/jasonette/core/base_spec.rb
+++ b/spec/lib/jasonette/core/base_spec.rb
@@ -194,4 +194,16 @@ RSpec.describe Jasonette::Base do
       end
     end
   end
+
+  describe "#encode" do
+    context "with private method" do
+      it do
+        pending "instance_eval is responcible to anounce private methods to object"
+        build = builder.encode do
+          _set_key_value "style", "wow"
+        end
+        expect(build).to_not eqj "style"=>"wow"
+      end
+    end
+  end
 end

--- a/spec/lib/jasonette/core/base_spec.rb
+++ b/spec/lib/jasonette/core/base_spec.rb
@@ -2,13 +2,6 @@ RSpec.describe Jasonette::Base do
 
   let(:builder) { build_with(described_class) }
 
-  context "#image_url" do
-    it "can use actionview asset helpers" do
-      build = builder.image_url("foo.png")
-      expect(build).to eq "/images/foo.png"
-    end
-  end
-
   context "partial!" do
     it "loads partials" do
       pending "it works within Rails app!  Why not here?"
@@ -169,28 +162,6 @@ RSpec.describe Jasonette::Base do
           merge! _builder
         end
         expect(build).to eqj "color"=>"1100"
-      end
-    end
-  end
-
-  describe "#as_json use" do
-    context "without defination of as_json", shared_context: :remove_as_json do
-      it "build wrong target!" do
-        _builder = build_with(Jasonette::Jason) { color "1100" }
-        build = builder.encode do
-          set! "style", [_builder]
-        end
-        expect(JSON.parse(build.target!)["style"].first).to_not include "color"
-      end
-    end
-
-    context "with defination of as_json" do
-      it "build target!" do
-        _builder = build_with(Jasonette::Jason) { color "1100" }
-        build = builder.encode do
-          set! "style", [_builder]
-        end
-        expect(JSON.parse(build.target!)).to eq "style" => [{"color"=>"1100"}]
       end
     end
   end

--- a/spec/lib/jasonette/jason/head_spec.rb
+++ b/spec/lib/jasonette/jason/head_spec.rb
@@ -58,13 +58,13 @@ RSpec.describe Jasonette::Jason::Head do
         title "Beatles"
         data.names ["John", "George", "Paul", "Ringo"]
         data.songs [
-            {album: "My Bonnie", song: "My Bonnie"},
-            {album: "My Bonnie", song: "Skinny Minnie"},
-            {album: "Please Please Me", song: "I Saw Her Standing There"},
+            {"album" => "My Bonnie", "song" => "My Bonnie"},
+            {"album" => "My Bonnie", "song" => "Skinny Minnie"},
+            {"album" => "Please Please Me", "song" => "I Saw Her Standing There"},
           ]
       end
 
-      expect(JSON.parse(results.target!)).to eq expected_with_songs
+      expect(results.attributes!).to eq expected_with_songs
     end
   end
 

--- a/spec/lib/jasonette/template_spec.rb
+++ b/spec/lib/jasonette/template_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Jasonette::Template do
         end
       end
 
-      expect(results).to eqj "{\"$jason\":{\"head\":{\"title\":\"Foobar\"}}}"
+      expect(results.target!).to eq "{\"$jason\":{\"head\":{\"title\":\"Foobar\"}}}"
     end
 
     it "#jason with head and title" do
@@ -20,7 +20,7 @@ RSpec.describe Jasonette::Template do
           title "Head"
         end
       end
-      expect(build).to eqj("$jason" => {"head" => {"title" => "Head"}})
+      expect(JSON.parse(build.target!)).to eq "$jason" => {"head" => {"title" => "Head"}}
     end
 
     it "#jason with head and title" do
@@ -30,14 +30,14 @@ RSpec.describe Jasonette::Template do
           foo "bar"
         end
       end
-      expect(build).to eqj("$jason" => {"head" => {"title" => "Head", "foo" => "bar"}})
+      expect(JSON.parse(build.target!)).to eq "$jason" => {"head" => {"title" => "Head", "foo" => "bar"}}
     end
 
     it "#jason with head and title" do
       build = builder.jason do
         head.title "Head"
       end
-      expect(build).to eqj("$jason" => {"head" => {"title" => "Head"}})
+      expect(JSON.parse(build.target!)).to eq "$jason" => {"head" => {"title" => "Head"}}
     end
 
     it "#jason with head and title" do
@@ -45,7 +45,7 @@ RSpec.describe Jasonette::Template do
         head.title "Head"
         head.foo "bar"
       end
-      expect(build).to eqj("$jason" => {"head" => {"title" => "Head", "foo" => "bar"}})
+      expect(JSON.parse(build.target!)).to eq "$jason" => {"head" => {"title" => "Head", "foo" => "bar"}}
     end
 
     it "#jason with head and title" do
@@ -55,7 +55,7 @@ RSpec.describe Jasonette::Template do
           header.title "Header"
         end
       end
-      expect(build).to eqj("$jason" => {"head" => {"title" => "Head"}, "body" => {"header" => {"title" => "Header"}}})
+      expect(JSON.parse(build.target!)).to eq "$jason" => {"head" => {"title" => "Head"}, "body" => {"header" => {"title" => "Header"}}}
     end
 
     it "#jason with head and title" do
@@ -63,7 +63,7 @@ RSpec.describe Jasonette::Template do
         head.title "Head"
         body.header.title "Header"
       end
-      expect(build).to eqj("$jason" => {"head" => {"title" => "Head"}, "body" => {"header" => {"title" => "Header"}}})
+      expect(JSON.parse(build.target!)).to eq "$jason" => {"head" => {"title" => "Head"}, "body" => {"header" => {"title" => "Header"}}}
     end
 
     it "#jason with head and title" do
@@ -73,7 +73,7 @@ RSpec.describe Jasonette::Template do
           foo "bar"
         end
       end
-      expect(build).to eqj("$jason" => {"head" => {"title" => "Foobar", "foo" => "bar"}})
+      expect(JSON.parse(build.target!)).to eq "$jason" => {"head" => {"title" => "Foobar", "foo" => "bar"}}
     end
 
     context "readme example" do
@@ -90,7 +90,7 @@ RSpec.describe Jasonette::Template do
               ]
             end
           end
-          expect(build.attributes!).to match_response_schema("readme_examples/data_blocks")
+          expect(JSON.parse(build.target!)).to match_response_schema("readme_examples/data_blocks")
         end
       end
 
@@ -103,7 +103,7 @@ RSpec.describe Jasonette::Template do
               style "col", font: "RobotoBold", color: "#FF0055"
             end
           end
-          expect(build.attributes!).to match_response_schema("readme_examples/style_blocks")
+          expect(JSON.parse(build.target!)).to match_response_schema("readme_examples/style_blocks")
         end
       end
     end
@@ -117,7 +117,36 @@ RSpec.describe Jasonette::Template do
         end
       end
 
-      expect(results).to eqj "{\"$$jason\":{\"head\":{\"title\":\"Foobar\"}}}"
+      expect(results.target!).to eq "{\"$$jason\":{\"head\":{\"title\":\"Foobar\"}}}"
+    end
+  end
+
+  context "#image_url" do
+    it "can use actionview asset helpers" do
+      build = builder.image_url("foo.png")
+      expect(build).to eq "/images/foo.png"
+    end
+  end
+
+  describe "#as_json use" do
+    context "without defination of as_json", shared_context: :remove_as_json do
+      it "build wrong target!" do
+        _builder = build_with(Jasonette::Jason) { color "1100" }
+        build = jbuild do
+          set! "style", [_builder]
+        end
+        expect(JSON.parse(build.target!)["$jason"]["style"].first).to_not include "color"
+      end
+    end
+
+    context "with defination of as_json" do
+      it "build target!" do
+        _builder = build_with(Jasonette::Jason) { color "1100" }
+        build = jbuild do
+          set! "style", [_builder]
+        end
+        expect(JSON.parse(build.target!)["$jason"]).to eq "style" => [{"color"=>"1100"}]
+      end
     end
   end
 end

--- a/spec/test_app/app/helpers/posts_helper.rb
+++ b/spec/test_app/app/helpers/posts_helper.rb
@@ -11,6 +11,14 @@ module PostsHelper
     end
   end 
 
+  def space_builder height, has_block
+    if has_block && eval(has_block)
+      jason_builder(:items).space height, &Proc.new { partial! "posts/foo" }
+    else
+      jason_builder(:items).space height
+    end
+  end
+
   def public_posts val
     { "public_helper_posts" => val }
   end

--- a/spec/test_app/app/views/layouts/jason.jasonette
+++ b/spec/test_app/app/views/layouts/jason.jasonette
@@ -2,5 +2,10 @@ head do
   if new_post_var.present?
     layout_local_var new_post_var
   end
+
+  if Thread.current[:sleepee]
+    Thread.stop
+  end
+
   merge! yield
 end

--- a/spec/test_app/app/views/posts/helper.jasonette
+++ b/spec/test_app/app/views/posts/helper.jasonette
@@ -17,3 +17,11 @@ head do
 
   merge! add_jason_builder_posts
 end
+
+body do
+  sections do
+    items do
+      merge! space_builder "10", params[:has_block]
+    end
+  end
+end

--- a/spec/test_app/spec/controllers/posts_controller_spec.rb
+++ b/spec/test_app/spec/controllers/posts_controller_spec.rb
@@ -6,54 +6,59 @@ describe PostsController do
   let!(:foo_post) { Post.create title: "Foo", body: "This is Foo" }
   let!(:bar_post) { Post.create title: "Bar", body: "That is Bar" }
 
-  describe "single file rendering" do
+  describe "rendering" do
     it "loads jBuilder" do
       expect(ActionView::Template::Handlers.extensions).to eq [:raw, :erb, :html, :builder, :ruby, :jasonette]
     end
 
-    it "render a list of posts" do
+    it "builds @posts" do
       request.accept = "application/json"
       get :index, format: :json
-      expect(JSON.parse(response.body)).to eq({"$jason"=>{"body"=>{"sections"=>[{"items"=>[{"text"=>"Foo", "type"=>"label"}, {"text"=>"Bar", "type"=>"label"}]}]}}})
+      expect(JSON.parse(response.body)).to eq({"$jason"=>{"body"=>{
+        "sections"=>[{"items"=>[{"text"=>"Foo", "type"=>"label"}, {"text"=>"Bar", "type"=>"label"}]}]}}})
     end
 
-    it "render a list of posts" do
-      request.accept = "application/json"
-      get :partial, format: :json
-      expect(JSON.parse(response.body)).to eq({"$jason"=>{"body"=>{"sections"=>[{"type"=>"partial", "items"=>[{"text"=>"Foo", "type"=>"label"}, {"text"=>"Bar", "type"=>"label"}]}]}, "foo"=>"bar"}})
-    end
+    context "partial!" do
+      it "builds @posts" do
+        request.accept = "application/json"
+        get :partial, format: :json
+        expect(JSON.parse(response.body)["$jason"]["body"]["sections"]).to include "type"=>"partial",
+          "items"=>[{"text"=>"Foo", "type"=>"label"}, {"text"=>"Bar", "type"=>"label"}]
+        expect(JSON.parse(response.body)["$jason"]).to include "foo"=>"bar"
+      end
 
-    let(:action_partial_json) do
-      { "$jason" => {
-          "head" => {
-            "title" => "Matchpoint",
-            "actions" => {
-              "$foreground" => { "type" => "$reload" },
-              "$pull" => { "type" => "$reload" },
-              "$load" => { "trigger" => "onload", "success" => { "type" => "$render" } },
-              "onload" => {
-                "type" => "$set",
-                "options" => { "authenticity_token" => "form_authenticity_token" },
-                "success" => { "trigger" => "set_score" },
-              },
+      let(:action_partial_json) do
+        {
+          "$jason" => {
+            "head" => {
+              "title" => "Matchpoint",
+              "actions" => {
+                "$foreground" => { "type" => "$reload" },
+                "$pull" => { "type" => "$reload" },
+                "$load" => { "trigger" => "onload", "success" => { "type" => "$render" } },
+                "onload" => { "type" => "$set",
+                  "options" => { "authenticity_token" => "form_authenticity_token" },
+                  "success" => { "trigger" => "set_score" }
+                }
+              }
             }
           }
         }
-      }
-    end
+      end
 
-    it "render a partial within an action" do
-      request.accept = "application/json"
-      get :action_partial, format: :json
+      it "builds template methods into an action" do
+        request.accept = "application/json"
+        get :action_partial, format: :json
 
-      expect(JSON.parse(response.body)).to eq action_partial_json
-    end
+        expect(JSON.parse(response.body)).to eq action_partial_json
+      end
 
-    it "render an action within a partial" do
-      request.accept = "application/json"
-      get :action_in_partial, format: :json
+      it "builds  an action in partial" do
+        request.accept = "application/json"
+        get :action_in_partial, format: :json
 
-      expect(JSON.parse(response.body)).to eq action_partial_json
+        expect(JSON.parse(response.body)).to eq action_partial_json
+      end
     end
   end
 
@@ -92,7 +97,7 @@ describe PostsController do
 
             expect do
               if thr1.status == "sleep"
-                Jasonette::JasonSingleton.class_variable_set('@@instances', [])
+                Jasonette::JasonSingleton.class_variable_get('@@instances').first.__locals = nil
                 thr1.wakeup; thr1.join
               end
             end.to raise_error StandardError
@@ -150,8 +155,20 @@ describe PostsController do
         request.accept = "application/json"
         get :helper, format: :json
         expect(JSON.parse(response.body)["$jason"]["head"]).to include "actions" => {"test"=>{"success"=>{"type"=>"$render"}}}
-      end  
-    end  
+      end
+
+      it "builds block with template methods" do
+        request.accept = "application/json"
+        get :helper, format: :json, params: { has_block: true }
+        expect(JSON.parse(response.body)["$jason"]["body"]).to include "sections"=>[{"items"=>[{"type"=>"space", "height"=>"10", "foo"=>"bar"}]}]
+      end
+
+      it "builds no need block" do
+        request.accept = "application/json"
+        get :helper, format: :json, params: { has_block: false }
+        expect(JSON.parse(response.body)["$jason"]["body"]).to include "sections"=>[{"items"=>[{"type"=>"space", "height"=>"10"}]}]
+      end
+    end
   end
 
   describe "#as_json use" do


### PR DESCRIPTION
Fixed below issue on multi-threaded requests
  - ActionView::Template::Error:undefined method `merge!' for nil:NilClass

Added  [spec](https://github.com/mwlang/jasonette-rails/pull/24/files#diff-d9e4301575216b4a2e04f1c10d6c3b53R198) for issue `private method is builds in #encode block`

Added changes to make core independent from Jasonette::Template