### PR TITLE
Helper to create components

### DIFF
--- a/lib/jasonette/core/properties.rb
+++ b/lib/jasonette/core/properties.rb
@@ -43,8 +43,12 @@ module Jasonette::Properties
     base.send :extend, ClassMethods
   end
 
+  def properties
+    self.class.properties
+  end
+
   def property_names
-    self.class.properties.names
+    properties.names
   end
 
   def property_variables
@@ -52,7 +56,7 @@ module Jasonette::Properties
   end
 
   TYPES.each do |type|
-    define_method("#{type}?") { |name| self.class.properties.has_type?(name, type) }
+    define_method("#{type}?") { |name| properties.has_type?(name, type) }
     define_method("ivar_#{type}_for_property") { |name| "@#{type}_#{name}" }
     define_method("get_#{type}_ivar") do |name|
       instance_variable_get(send("ivar_#{type}_for_property", name)) || (is_many?(name) ? [] : nil)

--- a/lib/jasonette/helpers.rb
+++ b/lib/jasonette/helpers.rb
@@ -1,14 +1,20 @@
 module Jasonette
   module Helpers
     def jason_builder property_name=nil, context=nil, &block
-      klass = Jasonette::Jason.new("").klass_for_property property_name
-
-      builder = builder(klass, context, &block)
+      builder = builder(property_name, context, &block)
       if ::Kernel.block_given?
         builder
       else
         BlockBuilder.new builder
       end
+    end
+
+    def jason_component name, *args, &block
+      builder = builder(:items, nil)
+      if !builder.public_methods.include?(name)
+        raise "Method `#{name}` is not defined in Builder"
+      end
+      builder.public_send(name, *args, &block)
     end
 
     class BlockBuilder
@@ -18,6 +24,9 @@ module Jasonette
       end
 
       def method_missing name, *args, &block
+        if !builder.public_methods.include?(name)
+          raise "Method `#{name}` is not defined in Builder"
+        end
         next_builder = builder.public_send name, *args
         j.encode(next_builder, &block) if ::Kernel.block_given?
         next_builder
@@ -31,7 +40,8 @@ module Jasonette
 
     private
 
-    def builder klass, context, &block
+    def builder property_name, context, &block
+      klass = Jasonette::Jason.new("").klass_for_property property_name
       klass.new(context || self, &block)
     end
   end

--- a/spec/lib/jasonette/helper_spec.rb
+++ b/spec/lib/jasonette/helper_spec.rb
@@ -1,0 +1,46 @@
+require 'jasonette/helpers'
+
+RSpec.describe Jasonette::Helpers do
+  before do
+    stub_const 'ContextBuilder', test_view_context_class.class
+    context.class_eval{ include Jasonette::Helpers }
+  end
+
+  after do
+    Jasonette::JasonSingleton.reset context
+  end
+
+  let(:context) { ContextBuilder.new }
+
+  context "#jason_builder" do
+    it "builds head" do
+      results =  context.jason_builder :head do
+        template :body do
+          title "Foobar"
+        end
+      end
+
+      expect(results).to eqj "templates" => {:body=>{"title"=>"Foobar"}}
+    end
+  end
+
+  context "#jason_component" do
+    it "raise Error" do
+      expect {
+        context.jason_component :head do
+          template :body
+        end
+      }.to raise_error "Method `head` is not defined in Builder"
+    end
+
+    it "builds component" do
+      results =  context.jason_component :textfield, :password, "Password" do
+        action do
+          success
+        end
+      end
+
+      expect(results).to eqj "name" => "password", "type" => "textfield", "value" => "Password", "action" => {"success"=>{"type"=>"$render"}}
+    end
+  end
+end


### PR DESCRIPTION
- Use `jason_component` helper to create any component directly without using `jason_builder` helper
