### PR TITLE
Fixed jason_component helper and template rendering syntax error issue

### DIFF
--- a/lib/jasonette/handler.rb
+++ b/lib/jasonette/handler.rb
@@ -7,7 +7,7 @@ module Jasonette
 
     def self.call(template)
       has_jasonette_handler = template.locals.include?("_jasonette_handler")
-      %{__already_defined = defined?(jason); jason ||= Jasonette::Template.load(self); if(jason && #{has_jasonette_handler}); jason.encode(_jasonette_handler, &Proc.new {#{template.source}}); else; if jason.has_layout?(#{template.object_id}); jason = jason.new_jason(#{template.object_id}); else; jason.jason(&Proc.new {#{template.source}}); end; end;
+      %{__already_defined = defined?(jason); jason ||= Jasonette::Template.load(self); if(jason && #{has_jasonette_handler}); jason.encode(_jasonette_handler, &Proc.new {#{template.source}\n}); else; if jason.has_layout?(#{template.object_id}); jason = jason.new_jason(#{template.object_id}); else; jason.jason(&Proc.new {#{template.source}\n}); end; end;
         jason.target! unless ((__already_defined && __already_defined != "method") || #{has_jasonette_handler})}
     end
   end

--- a/lib/jasonette/helpers.rb
+++ b/lib/jasonette/helpers.rb
@@ -14,7 +14,12 @@ module Jasonette
       if !builder.public_methods.include?(name)
         raise "Method `#{name}` is not defined in Builder"
       end
-      builder.public_send(name, *args, &block)
+      new_builder = builder.public_send(name, *args)
+      if ::Kernel.block_given?
+        j = JasonSingleton.fetch(new_builder.context)
+        j.encode(new_builder, &block)
+      end
+      new_builder
     end
 
     class BlockBuilder

--- a/spec/test_app/app/controllers/posts_controller.rb
+++ b/spec/test_app/app/controllers/posts_controller.rb
@@ -10,6 +10,10 @@ class PostsController < ApplicationController
     render file: "posts/with_template_vars", layout: "jason"
   end
 
+  def last_line
+    render :last_line, layout: "last_line"
+  end
+
   # GET /posts/new
   def new
     @post = Post.new

--- a/spec/test_app/app/helpers/posts_helper.rb
+++ b/spec/test_app/app/helpers/posts_helper.rb
@@ -19,6 +19,12 @@ module PostsHelper
     end
   end
 
+  def space_builder_jason_component height, has_block
+    if has_block && eval(has_block)
+      jason_component :space, height, &Proc.new { partial! "posts/foo" }
+    end
+  end
+
   def public_posts val
     { "public_helper_posts" => val }
   end

--- a/spec/test_app/app/views/layouts/last_line.jasonette
+++ b/spec/test_app/app/views/layouts/last_line.jasonette
@@ -1,0 +1,5 @@
+head do
+  set! "foo", "bar"
+end
+merge! yield
+# Last line

--- a/spec/test_app/app/views/posts/_last_line.jasonette
+++ b/spec/test_app/app/views/posts/_last_line.jasonette
@@ -1,0 +1,4 @@
+style do
+  color "blue"
+end
+# Last line

--- a/spec/test_app/app/views/posts/helper.jasonette
+++ b/spec/test_app/app/views/posts/helper.jasonette
@@ -24,4 +24,10 @@ body do
       merge! space_builder "10", params[:has_block]
     end
   end
+
+  sections do
+    items do
+      merge! space_builder_jason_component "40", "true"
+    end
+  end
 end

--- a/spec/test_app/app/views/posts/last_line.jasonette
+++ b/spec/test_app/app/views/posts/last_line.jasonette
@@ -1,0 +1,5 @@
+body do
+  set! "class", "foo"
+  partial! "last_line"
+end
+# Last line

--- a/spec/test_app/config/routes.rb
+++ b/spec/test_app/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
       get "without_layout"
       get "with_template_vars"
       get "as_json"
+      get "last_line"
     end
   end
 

--- a/spec/test_app/spec/controllers/posts_controller_spec.rb
+++ b/spec/test_app/spec/controllers/posts_controller_spec.rb
@@ -160,13 +160,21 @@ describe PostsController do
       it "builds block with template methods" do
         request.accept = "application/json"
         get :helper, format: :json, params: { has_block: true }
-        expect(JSON.parse(response.body)["$jason"]["body"]).to include "sections"=>[{"items"=>[{"type"=>"space", "height"=>"10", "foo"=>"bar"}]}]
+        expect(JSON.parse(response.body)["$jason"]["body"]["sections"]).to include "items"=>[{"type"=>"space", "height"=>"10", "foo"=>"bar"}]
       end
 
       it "builds no need block" do
         request.accept = "application/json"
         get :helper, format: :json, params: { has_block: false }
-        expect(JSON.parse(response.body)["$jason"]["body"]).to include "sections"=>[{"items"=>[{"type"=>"space", "height"=>"10"}]}]
+        expect(JSON.parse(response.body)["$jason"]["body"]["sections"]).to include "items"=>[{"type"=>"space", "height"=>"10"}]
+      end
+    end
+
+    context "have jason_component" do
+      it "builds block with template methods" do
+        request.accept = "application/json"
+        get :helper, format: :json, params: { has_block: true }
+        expect(JSON.parse(response.body)["$jason"]["body"]["sections"]).to include"items"=>[{"type"=>"space", "height"=>"40", "foo"=>"bar"}]
       end
     end
   end

--- a/spec/test_app/spec/controllers/posts_controller_spec.rb
+++ b/spec/test_app/spec/controllers/posts_controller_spec.rb
@@ -194,4 +194,12 @@ describe PostsController do
       end
     end
   end
+
+  describe "last commented line in layout, partial and template" do
+    it "builds without error" do
+      request.accept = "application/json"
+      get :last_line, format: :json
+      expect(JSON.parse(response.body)).to eq "$jason" => {"head"=>{"foo"=>"bar"}, "body"=>{"class"=>"foo", "style"=>{"color"=>"blue"}}}
+    end
+  end
 end


### PR DESCRIPTION
- Fixed jason_component helper to work with template methods like `partial!`
- Fixed syntax error issue in template rendering. 
  - last lines is commented in any jasonette template(partial, layout, template) then its not working.